### PR TITLE
Extract tree structure of suites and tests (#5)

### DIFF
--- a/test/structure.js
+++ b/test/structure.js
@@ -1,0 +1,76 @@
+const { stripIndent } = require('common-tags')
+const test = require('ava')
+const { getTestNames } = require('../src')
+
+test('extract complex structure', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    it('top', () => {})
+
+    describe('foo', {tags: ['@one', '@two']}, () => {
+
+      describe('foobar', {tags: ['@four']}, () => {
+        it('bar', {tags: ['@three']}, () => {})
+
+        it('quox', {tags: ['@five']}, () => {})
+      });
+
+      it('blipp', {tags: []}, () => {})
+    })
+
+    it('baz', {tags: ['@one']}, () => {})
+  `
+  const result = getTestNames(source, true)
+
+  t.deepEqual(result.structure, [
+    {
+      name: 'top',
+      tags: undefined,
+      type: 'test',
+      pending: false,
+    },
+    {
+      name: 'foo',
+      type: 'suite',
+      pending: false,
+      suites: [
+        {
+          name: 'foobar',
+          type: 'suite',
+          pending: false,
+          suites: [],
+          tests: [
+            {
+              name: 'bar',
+              tags: ['@three'],
+              type: 'test',
+              pending: false,
+            },
+            {
+              name: 'quox',
+              tags: ['@five'],
+              type: 'test',
+              pending: false,
+            },
+          ],
+          tags: ['@four'],
+        },
+      ],
+      tests: [
+        {
+          name: 'blipp',
+          tags: undefined,
+          type: 'test',
+          pending: false,
+        },
+      ],
+      tags: ['@one', '@two'],
+    },
+    {
+      name: 'baz',
+      tags: ['@one'],
+      type: 'test',
+      pending: false,
+    },
+  ])
+})

--- a/test/structure.js
+++ b/test/structure.js
@@ -74,3 +74,118 @@ test('extract complex structure', (t) => {
     },
   ])
 })
+
+test('structure with empty suites', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    it('top', () => {})
+
+    describe('foo', {tags: ['@one', '@two']}, () => {
+      describe('empty before', () => {
+        describe('empty before nested', () => {})
+      })
+
+      describe('foobar', {tags: ['@four']}, () => {
+        it('bar', {tags: ['@three']}, () => {})
+
+        it('quox', {tags: ['@five']}, () => {})
+      });
+
+      it('blipp', {tags: []}, () => {})
+
+      describe('empty after', () => {
+        describe('empty after nested', () => {})
+      })
+
+    })
+
+    it('baz', {tags: ['@one']}, () => {})
+  `
+  const result = getTestNames(source, true)
+
+  t.deepEqual(result.structure, [
+    {
+      name: 'top',
+      type: 'test',
+      pending: false,
+      tags: undefined,
+    },
+    {
+      name: 'foo',
+      type: 'suite',
+      pending: false,
+      suites: [
+        {
+          name: 'empty before',
+          type: 'suite',
+          pending: false,
+          suites: [
+            {
+              name: 'empty before nested',
+              type: 'suite',
+              pending: false,
+              suites: [],
+              tests: [],
+              tags: undefined,
+            },
+          ],
+          tests: [],
+          tags: undefined,
+        },
+        {
+          name: 'foobar',
+          type: 'suite',
+          pending: false,
+          suites: [],
+          tests: [
+            {
+              name: 'bar',
+              tags: ['@three'],
+              type: 'test',
+              pending: false,
+            },
+            {
+              name: 'quox',
+              tags: ['@five'],
+              type: 'test',
+              pending: false,
+            },
+          ],
+          tags: ['@four'],
+        },
+        {
+          name: 'empty after',
+          type: 'suite',
+          pending: false,
+          suites: [
+            {
+              name: 'empty after nested',
+              type: 'suite',
+              pending: false,
+              suites: [],
+              tests: [],
+              tags: undefined,
+            },
+          ],
+          tests: [],
+          tags: undefined,
+        },
+      ],
+      tests: [
+        {
+          name: 'blipp',
+          tags: undefined,
+          type: 'test',
+          pending: false,
+        },
+      ],
+      tags: ['@one', '@two'],
+    },
+    {
+      name: 'baz',
+      tags: ['@one'],
+      type: 'test',
+      pending: false,
+    },
+  ])
+})


### PR DESCRIPTION
Hi @bahmutov,

here's a draft PR that extracts the tree of suites and tests. 

The basic idea is that we use acorn's walk.ancestor to create an ancestor tree.
Since acorn traverses depth first, the first node we get will usually be an it node, and we traverse upwards through the node's ancestors looking for the parent describes.
To minimize traversal, we use a cache for already visited nodes.
Since we build the tree from it nodes, we need to special case empty describe nodes (separate commit).

It is obviously a bit overhead to traverse the tree like this, but I don't think it'll make a big difference in practice.
Although traversing from the top of the tree is generally a bit easier to understand. However, we would need to switch AST walkers for that.

The structure uses arrays to store suites and tests. Using test / suite names as keys could lead to collisions with other properties. I also added the tags.

Let me know what you think, and if you think it looks okay, I'll clean up the rest:

- remove duplicated extraction of describes
- add tests for structure and .only
- split complex test into simple and tagged