### PR TITLE
feat: compute the full names of suites and tests

### DIFF
--- a/test/counts.js
+++ b/test/counts.js
@@ -5,12 +5,14 @@ const { getTestNames } = require('../src')
 // common structure for two tests we expect to find
 const twoTests = [
   {
+    fullName: 'works a',
     name: 'works a',
     type: 'test',
     pending: false,
     tags: undefined,
   },
   {
+    fullName: 'works b',
     name: 'works b',
     type: 'test',
     pending: false,
@@ -52,6 +54,7 @@ test('suite counts the tests inside', (t) => {
   const result = getTestNames(source, true)
   t.deepEqual(result.structure, [
     {
+      fullName: 'loads',
       name: 'loads',
       type: 'suite',
       pending: false,
@@ -60,7 +63,10 @@ test('suite counts the tests inside', (t) => {
       suiteCount: 0,
       // counts all tests inside
       testCount: 2,
-      tests: twoTests,
+      tests: twoTests.map((test) => ({
+        ...test,
+        fullName: `loads ${test.name}`,
+      })),
       pendingTestCount: 0,
     },
   ])
@@ -85,6 +91,7 @@ test('suite counts the tests inside inner suites', (t) => {
   const result = getTestNames(source, true)
   t.deepEqual(result.structure, [
     {
+      fullName: 'parent',
       name: 'parent',
       type: 'suite',
       pending: false,
@@ -92,6 +99,7 @@ test('suite counts the tests inside inner suites', (t) => {
       pendingTestCount: 0,
       suites: [
         {
+          fullName: 'parent inner1',
           name: 'inner1',
           type: 'suite',
           pending: false,
@@ -99,10 +107,14 @@ test('suite counts the tests inside inner suites', (t) => {
           suites: [],
           suiteCount: 0,
           testCount: 2,
-          tests: twoTests,
+          tests: twoTests.map((test) => ({
+            ...test,
+            fullName: `parent inner1 ${test.name}`,
+          })),
           pendingTestCount: 0,
         },
         {
+          fullName: 'parent inner2',
           name: 'inner2',
           type: 'suite',
           pending: false,
@@ -110,7 +122,10 @@ test('suite counts the tests inside inner suites', (t) => {
           suites: [],
           suiteCount: 0,
           testCount: 2,
-          tests: twoTests,
+          tests: twoTests.map((test) => ({
+            ...test,
+            fullName: `parent inner2 ${test.name}`,
+          })),
           pendingTestCount: 0,
         },
       ],
@@ -154,6 +169,7 @@ test('handles counts in deeply nested structure', (t) => {
   t.deepEqual(result.structure, [
     {
       name: 'foo',
+      fullName: 'foo',
       type: 'suite',
       pending: false,
       tags: undefined,
@@ -163,6 +179,7 @@ test('handles counts in deeply nested structure', (t) => {
       suites: [
         {
           name: 'child1',
+          fullName: 'foo child1',
           type: 'suite',
           pending: false,
           suites: [],
@@ -172,12 +189,14 @@ test('handles counts in deeply nested structure', (t) => {
           tests: [
             {
               name: 'bar',
+              fullName: 'foo child1 bar',
               tags: undefined,
               type: 'test',
               pending: false,
             },
             {
               name: 'quox',
+              fullName: 'foo child1 quox',
               tags: undefined,
               type: 'test',
               pending: false,
@@ -187,6 +206,7 @@ test('handles counts in deeply nested structure', (t) => {
         },
         {
           name: 'child2',
+          fullName: 'foo child2',
           type: 'suite',
           pending: false,
           suiteCount: 2,
@@ -196,6 +216,7 @@ test('handles counts in deeply nested structure', (t) => {
           suites: [
             {
               name: 'grandchild1',
+              fullName: 'foo child2 grandchild1',
               type: 'suite',
               pending: false,
               suiteCount: 1,
@@ -205,6 +226,7 @@ test('handles counts in deeply nested structure', (t) => {
               suites: [
                 {
                   name: 'greatgrandchild1',
+                  fullName: 'foo child2 grandchild1 greatgrandchild1',
                   type: 'suite',
                   pending: false,
                   suiteCount: 0,
@@ -215,6 +237,8 @@ test('handles counts in deeply nested structure', (t) => {
                   tests: [
                     {
                       name: 'greatgrandchild1-test',
+                      fullName:
+                        'foo child2 grandchild1 greatgrandchild1 greatgrandchild1-test',
                       pending: false,
                       tags: undefined,
                       type: 'test',
@@ -225,6 +249,7 @@ test('handles counts in deeply nested structure', (t) => {
               tests: [
                 {
                   name: 'grandchild1-test',
+                  fullName: 'foo child2 grandchild1 grandchild1-test',
                   pending: false,
                   tags: undefined,
                   type: 'test',
@@ -235,6 +260,7 @@ test('handles counts in deeply nested structure', (t) => {
           tests: [
             {
               name: 'baz',
+              fullName: 'foo child2 baz',
               pending: false,
               tags: undefined,
               type: 'test',
@@ -245,6 +271,7 @@ test('handles counts in deeply nested structure', (t) => {
       tests: [
         {
           name: 'blipp',
+          fullName: 'foo blipp',
           tags: undefined,
           type: 'test',
           pending: false,
@@ -264,6 +291,7 @@ test('counts pending tests', (t) => {
   const result = getTestNames(source, true)
   t.deepEqual(result.structure, [
     {
+      fullName: 'foo',
       name: 'foo',
       type: 'suite',
       pending: false,
@@ -274,6 +302,7 @@ test('counts pending tests', (t) => {
       pendingTestCount: 1,
       tests: [
         {
+          fullName: 'foo bar',
           name: 'bar',
           type: 'test',
           pending: true,

--- a/test/structure.js
+++ b/test/structure.js
@@ -19,6 +19,7 @@ test('handles pending test', (t) => {
 
   t.deepEqual(result.structure, [
     {
+      fullName: 'will be added later',
       name: 'will be added later',
       pending: true,
       tags: undefined,
@@ -36,6 +37,7 @@ test('handles a single test', (t) => {
 
   t.deepEqual(result.structure, [
     {
+      fullName: 'works',
       name: 'works',
       pending: false,
       tags: undefined,
@@ -45,7 +47,7 @@ test('handles a single test', (t) => {
 })
 
 test('extract complex structure', (t) => {
-  t.plan(1)
+  t.plan(3)
   const source = stripIndent`
     it('top', () => {})
 
@@ -64,14 +66,26 @@ test('extract complex structure', (t) => {
   `
   const result = getTestNames(source, true)
 
+  t.deepEqual(result.fullTestNames, [
+    'baz',
+    'foo blipp',
+    'foo foobar bar',
+    'foo foobar quox',
+    'top',
+  ])
+
+  t.deepEqual(result.fullSuiteNames, ['foo', 'foo foobar'])
+
   t.deepEqual(result.structure, [
     {
+      fullName: 'top',
       name: 'top',
       tags: undefined,
       type: 'test',
       pending: false,
     },
     {
+      fullName: 'foo',
       name: 'foo',
       type: 'suite',
       pending: false,
@@ -80,6 +94,7 @@ test('extract complex structure', (t) => {
       pendingTestCount: 0,
       suites: [
         {
+          fullName: 'foo foobar',
           name: 'foobar',
           type: 'suite',
           pending: false,
@@ -89,12 +104,14 @@ test('extract complex structure', (t) => {
           suites: [],
           tests: [
             {
+              fullName: 'foo foobar bar',
               name: 'bar',
               tags: ['@three'],
               type: 'test',
               pending: false,
             },
             {
+              fullName: 'foo foobar quox',
               name: 'quox',
               tags: ['@five'],
               type: 'test',
@@ -106,6 +123,7 @@ test('extract complex structure', (t) => {
       ],
       tests: [
         {
+          fullName: 'foo blipp',
           name: 'blipp',
           tags: undefined,
           type: 'test',
@@ -115,6 +133,7 @@ test('extract complex structure', (t) => {
       tags: ['@one', '@two'],
     },
     {
+      fullName: 'baz',
       name: 'baz',
       tags: ['@one'],
       type: 'test',
@@ -124,7 +143,7 @@ test('extract complex structure', (t) => {
 })
 
 test('structure with empty suites', (t) => {
-  t.plan(1)
+  t.plan(3)
   const source = stripIndent`
     it('top', () => {})
 
@@ -151,14 +170,33 @@ test('structure with empty suites', (t) => {
   `
   const result = getTestNames(source, true)
 
+  t.deepEqual(result.fullTestNames, [
+    'baz',
+    'foo blipp',
+    'foo foobar bar',
+    'foo foobar quox',
+    'top',
+  ])
+
+  t.deepEqual(result.fullSuiteNames, [
+    'foo',
+    'foo empty after',
+    'foo empty after empty after nested',
+    'foo empty before',
+    'foo empty before empty before nested',
+    'foo foobar',
+  ])
+
   t.deepEqual(result.structure, [
     {
+      fullName: 'top',
       name: 'top',
       type: 'test',
       pending: false,
       tags: undefined,
     },
     {
+      fullName: 'foo',
       name: 'foo',
       type: 'suite',
       pending: false,
@@ -168,6 +206,7 @@ test('structure with empty suites', (t) => {
       pendingTestCount: 0,
       suites: [
         {
+          fullName: 'foo empty before',
           name: 'empty before',
           type: 'suite',
           pending: false,
@@ -176,6 +215,7 @@ test('structure with empty suites', (t) => {
           pendingTestCount: 0,
           suites: [
             {
+              fullName: 'foo empty before empty before nested',
               name: 'empty before nested',
               type: 'suite',
               pending: false,
@@ -191,6 +231,7 @@ test('structure with empty suites', (t) => {
           tags: undefined,
         },
         {
+          fullName: 'foo foobar',
           name: 'foobar',
           type: 'suite',
           pending: false,
@@ -200,12 +241,14 @@ test('structure with empty suites', (t) => {
           suites: [],
           tests: [
             {
+              fullName: 'foo foobar bar',
               name: 'bar',
               tags: ['@three'],
               type: 'test',
               pending: false,
             },
             {
+              fullName: 'foo foobar quox',
               name: 'quox',
               tags: ['@five'],
               type: 'test',
@@ -215,6 +258,7 @@ test('structure with empty suites', (t) => {
           tags: ['@four'],
         },
         {
+          fullName: 'foo empty after',
           name: 'empty after',
           type: 'suite',
           pending: false,
@@ -223,6 +267,7 @@ test('structure with empty suites', (t) => {
           pendingTestCount: 0,
           suites: [
             {
+              fullName: 'foo empty after empty after nested',
               name: 'empty after nested',
               type: 'suite',
               pending: false,
@@ -240,6 +285,7 @@ test('structure with empty suites', (t) => {
       ],
       tests: [
         {
+          fullName: 'foo blipp',
           name: 'blipp',
           tags: undefined,
           type: 'test',
@@ -248,6 +294,7 @@ test('structure with empty suites', (t) => {
       ],
     },
     {
+      fullName: 'baz',
       name: 'baz',
       tags: ['@one'],
       type: 'test',


### PR DESCRIPTION
"full name" means the name prepended with all parent suite names.

This can be useful for cypress-grep and grepFilterSpecs.

At the moment grepFilterSpecs tests against the direct names
of tests and suites to determine if a spec should run.

Consider the following case:

```
    describe('parent', () => {
      describe('inner', () => {
        it('works a', () => {})
        it('works b', () => {})
      })
    })
```

and `grep=-parent`

The spec file cannot be filtered by grepFilterSpecs because
the inner suite, and the two tests don't have parent in the name. (The tests will be skipped during run-time instead).

With the full name, all suites and tests will be excluded and the spec file is never loaded.