### PR TITLE
feat: find tests described using "specify" (#32)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,12 +15,13 @@ const isDescribeSkip = (node) =>
   node.callee.property.name === 'skip'
 
 const isIt = (node) =>
-  node.type === 'CallExpression' && node.callee.name === 'it'
+  node.type === 'CallExpression' && 
+  ( node.callee.name === 'it' || node.callee.name === 'specify' )
 
 const isItSkip = (node) =>
   node.type === 'CallExpression' &&
   node.callee.type === 'MemberExpression' &&
-  node.callee.object.name === 'it' &&
+  ( node.callee.object.name === 'it' || node.callee.object.name === 'specify' ) &&
   node.callee.property.name === 'skip'
 
 const getTags = (source, node) => {

--- a/test/basic.js
+++ b/test/basic.js
@@ -71,3 +71,29 @@ test('context', (t) => {
     ],
   })
 })
+
+test('specify', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    describe('foo', () => {
+      specify('bar', () => {})
+    })
+  `
+  const result = getTestNames(source)
+  t.deepEqual(result, {
+    suiteNames: ['foo'],
+    testNames: ['bar'],
+    tests: [
+      {
+        name: 'bar',
+        type: 'test',
+        pending: false,
+      },
+      {
+        name: 'foo',
+        type: 'suite',
+        pending: false,
+      },
+    ],
+  })
+})


### PR DESCRIPTION
This PR adds support for the "specify" keyword, that can be used to create tests in the same way as "it" does.

See the related issue: #32 