### PR TITLE
fix: TypeError "Cannot read properties of null (reading 'type')" when tests contains for-of loop

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npm run stop-only; npm test
+npm test

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "demo-update-md": "DEBUG=find-test-names node bin/update-test-count.js out.md 'test-cy/**/*.js'",
     "demo-print": "node bin/print-tests.js 'test-cy/**/*.js'",
     "stop-only": "DEBUG=stop-only stop-only --folder test --exclude exclusive.js",
-    "prepare": "husky install",
+    "prepare": "husky",
     "deps": "npm audit --report --omit dev"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -722,8 +722,9 @@ function getTestNames(source, withStructure, currentFilename) {
             .filter((decl) => decl.id.type === 'Identifier')
             .filter(
               (decl) =>
-                decl.init.type === 'Literal' ||
-                decl.init.type === 'ObjectExpression',
+                decl.init && 
+                  (decl.init.type === 'Literal' ||
+                    decl.init.type === 'ObjectExpression'),
             )
             .forEach((decl) => {
               if (decl.init.type === 'ObjectExpression') {

--- a/test/for-of.js
+++ b/test/for-of.js
@@ -1,0 +1,31 @@
+const { stripIndent } = require('common-tags')
+const test = require('ava')
+const { getTestNames } = require('../src')
+
+test('for of loop', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    describe('foo', () => {
+      it('bar', () => {
+        for (const c of []);
+      })
+    })
+  `
+  const result = getTestNames(source)
+  t.deepEqual(result, {
+    suiteNames: ['foo'],
+    testNames: ['bar'],
+    tests: [
+      {
+        name: 'bar',
+        type: 'test',
+        pending: false,
+      },
+      {
+        name: 'foo',
+        type: 'suite',
+        pending: false,
+      },
+    ],
+  })
+})


### PR DESCRIPTION
Tests that contained for-of loops like `for (const c of ['list', 'of', 'values'])` resulted in a TypeError.

The pr also contains some small changes that are needed after the update of husky to v9.