### PR TITLE
Support importing tags from other files

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ it('works', { tags: '@user' })
 
 But sometimes you want to use variables to set them. To be able to statically analyze the source files, this package currently supports:
 
-- local constants
+#### local constants
 
 ```js
 const USER = '@user'
@@ -138,7 +138,7 @@ it('works', { tags: USER })
 it('works', { tags: ['@sanity', USER] })
 ```
 
-- local objects with literal property access
+#### Local objects with literal property access
 
 ```js
 const TAGS = {
@@ -148,6 +148,96 @@ const TAGS = {
 // in the same file
 it('works', { tags: TAGS.user })
 it('works', { tags: ['@sanity', TAGS.user] })
+```
+
+#### Imported values (named imports)
+
+```js
+// tags.js
+export const userTag = '@user'
+export const adminTag = '@admin'
+
+// spec.cy.js
+import { userTag, adminTag } from './tags'
+
+it('works for user', { tags: userTag })
+it('works for admin', { tags: adminTag })
+```
+
+#### Imported values (default imports)
+
+```js
+// tag.js
+export default '@smoke'
+
+// spec.cy.js
+import smokeTag from './tag'
+
+it('works', { tags: smokeTag })
+```
+
+Default object imports are also supported:
+
+```js
+// roles.js
+export default {
+  user: '@user',
+  admin: '@admin'
+}
+
+// spec.cy.js
+import roles from './roles'
+
+it('works for user', { tags: roles.user })
+it('works for admin', { tags: roles.admin })
+```
+
+#### Imported values (namespace imports)
+
+```js
+// tags.js
+export const smoke = '@smoke'
+export const regression = '@regression'
+
+// spec.cy.js
+import * as Tags from './tags'
+
+it('smoke test', { tags: Tags.smoke })
+it('regression test', { tags: Tags.regression })
+```
+
+#### TypeScript enums
+
+```js
+// tags.ts
+export enum TestTags {
+  smoke = '@smoke',
+  regression = '@regression'
+}
+
+// spec.cy.js
+import { TestTags } from './tags'
+
+it('smoke test', { tags: TestTags.smoke })
+it('regression test', { tags: TestTags.regression })
+```
+
+Namespace imports with enums are also supported:
+
+```js
+import * as TagsModule from './tags'
+
+it('test', { tags: TagsModule.TestTags.smoke })
+```
+
+#### File extension resolution
+
+Import paths automatically resolve `.js` and `.ts` extensions:
+
+```js
+// Both work the same way
+import { tag } from './tags'      // resolves to ./tags.js or ./tags.ts
+import { tag } from './tags.js'   // explicit extension
 ```
 
 ### Bin

--- a/src/relative-path-resolver.js
+++ b/src/relative-path-resolver.js
@@ -23,7 +23,7 @@ function relativePathResolver(currentFilename) {
     }
 
     // Try with .ts and .js extensions
-    const extensions = ['.ts', '.js']
+    const extensions = ['.js', '.ts']
     for (const ext of extensions) {
       const resolvedWithExt = resolved + ext
       if (fs.existsSync(resolvedWithExt)) {

--- a/src/relative-path-resolver.js
+++ b/src/relative-path-resolver.js
@@ -17,13 +17,23 @@ function relativePathResolver(currentFilename) {
       resolved,
     )
 
-    const exists = fs.existsSync(resolved)
-    if (!exists) {
-      debug('"%s" does not exist', resolved)
-      return
+    // Try the original path first
+    if (fs.existsSync(resolved)) {
+      return fs.readFileSync(resolved, 'utf-8')
     }
 
-    return fs.readFileSync(resolved, 'utf-8')
+    // Try with .ts and .js extensions
+    const extensions = ['.ts', '.js']
+    for (const ext of extensions) {
+      const resolvedWithExt = resolved + ext
+      if (fs.existsSync(resolvedWithExt)) {
+        debug('found "%s" with extension "%s"', resolved, ext)
+        return fs.readFileSync(resolvedWithExt, 'utf-8')
+      }
+    }
+
+    debug('"%s[.js|.ts]" does not exist', resolved)
+    return
   }
 }
 

--- a/test/fixture-default/roles.js
+++ b/test/fixture-default/roles.js
@@ -1,0 +1,5 @@
+export default {
+  admin: '@admin',
+  user: '@user-obj',
+  guest: '@guest'
+}

--- a/test/fixture-default/spec-object.cy.js
+++ b/test/fixture-default/spec-object.cy.js
@@ -1,0 +1,7 @@
+import roles from './roles'
+
+it('default object test 1', { tags: roles.admin })
+
+it('default object test 2', { tags: roles.user })
+
+it('default object test 3', { tags: roles.guest })

--- a/test/fixture-default/spec.cy.js
+++ b/test/fixture-default/spec.cy.js
@@ -1,0 +1,3 @@
+import defaultTag from './tag'
+
+it('default import test', { tags: defaultTag })

--- a/test/fixture-default/tag.js
+++ b/test/fixture-default/tag.js
@@ -1,0 +1,1 @@
+export default '@default-tag'

--- a/test/fixture-enum/spec.cy.js
+++ b/test/fixture-enum/spec.cy.js
@@ -1,0 +1,7 @@
+import { TestTags } from './tags'
+
+it('enum test 1', { tags: TestTags.smoke })
+
+it('enum test 2', { tags: TestTags.regression })
+
+it('enum test 3', { tags: TestTags.sanity })

--- a/test/fixture-enum/tags.ts
+++ b/test/fixture-enum/tags.ts
@@ -1,0 +1,5 @@
+export enum TestTags {
+  smoke = '@smoke-enum',
+  regression = '@regression-enum',
+  sanity = '@sanity-enum'
+}

--- a/test/fixture-extensions/config.ts
+++ b/test/fixture-extensions/config.ts
@@ -1,0 +1,2 @@
+export const envTag = '@production'
+export const debugTag = '@debug'

--- a/test/fixture-extensions/spec2.cy.js
+++ b/test/fixture-extensions/spec2.cy.js
@@ -1,0 +1,5 @@
+import { smokeTag, regressionTag } from './tags'
+
+it('test 1', { tags: smokeTag })
+
+it('test 2', { tags: regressionTag })

--- a/test/fixture-extensions/spec3.cy.js
+++ b/test/fixture-extensions/spec3.cy.js
@@ -1,0 +1,5 @@
+import { envTag, debugTag } from './config'
+
+it('test with ts import 1', { tags: envTag })
+
+it('test with ts import 2', { tags: debugTag })

--- a/test/fixture-extensions/tags.js
+++ b/test/fixture-extensions/tags.js
@@ -1,0 +1,2 @@
+export const smokeTag = '@smoke'
+export const regressionTag = '@regression'

--- a/test/fixture-mixed/exports.ts
+++ b/test/fixture-mixed/exports.ts
@@ -1,0 +1,2 @@
+export const namedTag = '@named'
+export default '@default-mixed'

--- a/test/fixture-mixed/spec.cy.js
+++ b/test/fixture-mixed/spec.cy.js
@@ -1,0 +1,5 @@
+import defaultMixed, { namedTag } from './exports'
+
+it('mixed default test', { tags: defaultMixed })
+
+it('mixed named test', { tags: namedTag })

--- a/test/fixture-namespace/enum-tags.ts
+++ b/test/fixture-namespace/enum-tags.ts
@@ -1,0 +1,4 @@
+export enum TestTags {
+  smoke = '@smoke-ns-enum',
+  regression = '@regression-ns-enum'
+}

--- a/test/fixture-namespace/spec-enum.cy.js
+++ b/test/fixture-namespace/spec-enum.cy.js
@@ -1,0 +1,5 @@
+import * as TagsModule from './enum-tags'
+
+it('namespace enum test 1', { tags: TagsModule.TestTags.smoke })
+
+it('namespace enum test 2', { tags: TagsModule.TestTags.regression })

--- a/test/fixture-namespace/spec.cy.js
+++ b/test/fixture-namespace/spec.cy.js
@@ -1,0 +1,7 @@
+import * as allTags from './tags'
+
+it('namespace test 1', { tags: allTags.smokeTag })
+
+it('namespace test 2', { tags: allTags.regressionTag })
+
+it('namespace test 3', { tags: allTags.userTag })

--- a/test/fixture-namespace/tags.js
+++ b/test/fixture-namespace/tags.js
@@ -1,0 +1,3 @@
+export const smokeTag = '@smoke'
+export const regressionTag = '@regression'
+export const userTag = '@user'

--- a/test/fixture1/spec1.cy.js
+++ b/test/fixture1/spec1.cy.js
@@ -1,5 +1,5 @@
 import { userTag } from './tags.js'
 
-it('works 1')
+it('works 1', { tags: userTag })
 
-it('works 2')
+it('works 2', { tags: userTag })

--- a/test/resolve-exports.js
+++ b/test/resolve-exports.js
@@ -23,3 +23,56 @@ test('finds the named exported object', (t) => {
   const result = resolveExports(source)
   t.deepEqual(result, { TAGS: { foo: 'foo', bar: 'bar' } })
 })
+
+test('finds the default export with a literal', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    export default 'foo'
+  `
+  const result = resolveExports(source)
+  t.deepEqual(result, { default: 'foo' })
+})
+
+test('finds the default export with an object', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    export default {
+      foo: 'foo',
+      bar: 'bar'
+    }
+  `
+  const result = resolveExports(source)
+  t.deepEqual(result, { default: { foo: 'foo', bar: 'bar' } })
+})
+
+test('finds the default export with an identifier', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    const myValue = 'foo'
+    export default myValue
+  `
+  const result = resolveExports(source)
+  t.deepEqual(result, { default: 'myValue' })
+})
+
+test('finds both named and default exports', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    export const named = 'namedValue'
+    export default 'defaultValue'
+  `
+  const result = resolveExports(source)
+  t.deepEqual(result, { named: 'namedValue', default: 'defaultValue' })
+})
+
+test('finds the exported TypeScript enum', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    export enum Tags {
+      smoke = '@smoke',
+      regression = '@regression'
+    }
+  `
+  const result = resolveExports(source)
+  t.deepEqual(result, { Tags: { smoke: '@smoke', regression: '@regression' } })
+})

--- a/test/resolve-imports.js
+++ b/test/resolve-imports.js
@@ -18,6 +18,28 @@ const fileProvider = (relativePath) => {
       }
     `
   }
+
+  if (relativePath === './file-c') {
+    return stripIndent`
+      export default '@smoke'
+    `
+  }
+
+  if (relativePath === './file-d') {
+    return stripIndent`
+      export default {
+        env: 'production',
+        debug: 'false'
+      }
+    `
+  }
+
+  if (relativePath === './file-e') {
+    return stripIndent`
+      export const named = 'namedValue'
+      export default 'defaultValue'
+    `
+  }
 }
 
 test('finds the imports', (t) => {
@@ -68,4 +90,54 @@ test('finds the exported object', (t) => {
 
   const result = resolveImports(source, fileProvider)
   t.deepEqual(result, { TAGS: { user: '@user', sanity: '@sanity' } })
+})
+
+test('imports default export with literal', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    import defaultTag from './file-c'
+  `
+
+  const result = resolveImports(source, fileProvider)
+  t.deepEqual(result, { defaultTag: '@smoke' })
+})
+
+test('imports default export with object', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    import config from './file-d'
+  `
+
+  const result = resolveImports(source, fileProvider)
+  t.deepEqual(result, { config: { env: 'production', debug: 'false' } })
+})
+
+test('imports both named and default exports', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    import defaultValue, { named } from './file-e'
+  `
+
+  const result = resolveImports(source, fileProvider)
+  t.deepEqual(result, { defaultValue: 'defaultValue', named: 'namedValue' })
+})
+
+test('imports namespace', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    import * as allExports from './file-a'
+  `
+
+  const result = resolveImports(source, fileProvider)
+  t.deepEqual(result, { allExports: { foo: 'foo', bar: 'bar' } })
+})
+
+test('imports namespace with default export', (t) => {
+  t.plan(1)
+  const source = stripIndent`
+    import * as allExports from './file-e'
+  `
+
+  const result = resolveImports(source, fileProvider)
+  t.deepEqual(result, { allExports: { named: 'namedValue', default: 'defaultValue' } })
 })

--- a/test/tags-imported-from-another-file.js
+++ b/test/tags-imported-from-another-file.js
@@ -3,9 +3,93 @@ const test = require('ava')
 const path = require('path')
 
 test('individual tags imported from another file', (t) => {
-  t.plan(0)
+  t.plan(2)
 
   const fullName = path.join(__dirname, './fixture1/spec1.cy.js')
   const result = findEffectiveTestTagsIn(fullName)
-  console.log(result)
+
+  t.deepEqual(result['works 1'].effectiveTags, ['@user'])
+  t.deepEqual(result['works 2'].effectiveTags, ['@user'])
+})
+
+test('imports without file extension (.js)', (t) => {
+  t.plan(2)
+
+  const fullName = path.join(__dirname, './fixture-extensions/spec2.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['test 1'].effectiveTags, ['@smoke'])
+  t.deepEqual(result['test 2'].effectiveTags, ['@regression'])
+})
+
+test('imports without file extension (.ts)', (t) => {
+  t.plan(2)
+
+  const fullName = path.join(__dirname, './fixture-extensions/spec3.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['test with ts import 1'].effectiveTags, ['@production'])
+  t.deepEqual(result['test with ts import 2'].effectiveTags, ['@debug'])
+})
+
+test('imports from TypeScript enum', (t) => {
+  t.plan(3)
+
+  const fullName = path.join(__dirname, './fixture-enum/spec.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['enum test 1'].effectiveTags, ['@smoke-enum'])
+  t.deepEqual(result['enum test 2'].effectiveTags, ['@regression-enum'])
+  t.deepEqual(result['enum test 3'].effectiveTags, ['@sanity-enum'])
+})
+
+test('default import with string', (t) => {
+  t.plan(1)
+
+  const fullName = path.join(__dirname, './fixture-default/spec.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['default import test'].effectiveTags, ['@default-tag'])
+})
+
+test('default import with object', (t) => {
+  t.plan(3)
+
+  const fullName = path.join(__dirname, './fixture-default/spec-object.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['default object test 1'].effectiveTags, ['@admin'])
+  t.deepEqual(result['default object test 2'].effectiveTags, ['@user-obj'])
+  t.deepEqual(result['default object test 3'].effectiveTags, ['@guest'])
+})
+
+test('namespace import', (t) => {
+  t.plan(3)
+
+  const fullName = path.join(__dirname, './fixture-namespace/spec.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['namespace test 1'].effectiveTags, ['@smoke'])
+  t.deepEqual(result['namespace test 2'].effectiveTags, ['@regression'])
+  t.deepEqual(result['namespace test 3'].effectiveTags, ['@user'])
+})
+
+test('namespace import with enum', (t) => {
+  t.plan(2)
+
+  const fullName = path.join(__dirname, './fixture-namespace/spec-enum.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['namespace enum test 1'].effectiveTags, ['@smoke-ns-enum'])
+  t.deepEqual(result['namespace enum test 2'].effectiveTags, ['@regression-ns-enum'])
+})
+
+test('mixed default and named imports', (t) => {
+  t.plan(2)
+
+  const fullName = path.join(__dirname, './fixture-mixed/spec.cy.js')
+  const result = findEffectiveTestTagsIn(fullName)
+
+  t.deepEqual(result['mixed default test'].effectiveTags, ['@default-mixed'])
+  t.deepEqual(result['mixed named test'].effectiveTags, ['@named'])
 })


### PR DESCRIPTION
  - Add support for named/default/namespace imports
  - Add support for named/default exports of constants, objects, and enums
  - Add TypeScript enum export/import support
  - Add automatic .js and .ts file extension resolution

I believe this should fix https://github.com/bahmutov/find-test-names/issues/78

This is quite a few changes. I wanted to add support for most ways to import/export, plus handle the case where files are imported without an extension at all, but if you'd rather support only a subset of this I'm happy to rip out whatever you want. I'm also happy to make whatever changes you want if this isn't how you envisioned supporting importing tags from files would work.